### PR TITLE
关于时序数据参考答案习题一中 `get_loc` 方法的问题

### DIFF
--- a/notebook/参考答案.ipynb
+++ b/notebook/参考答案.ipynb
@@ -2630,7 +2630,8 @@
    ],
    "source": [
     "my_dt = df.index.shift(freq='-6H')\n",
-    "int_loc = [df.index.get_loc(i, method='nearest') for i in my_dt]\n",
+    "int_loc = [df.index.get_indexer([i], method='nearest') for i in my_dt]\n",
+    "int_loc = np.array(int_loc).reshape(-1)\n"
     "res = df.Radiation.iloc[int_loc]\n",
     "res.tail(3)"
    ]


### PR DESCRIPTION
我用的 pandas版本为1.4.2，做练习的时候发现原来的代码 `int_loc = [df.index.get_loc(i, method='nearest') for i in my_dt]` 中的方法 `get_loc`  出现 Future Warning，而且无法得到相应答案，提示使用 `get_indexer` 方法，所以将代码改为

```
# work for pandas version 1.4.2
my_dt = df.index.shift(freq='-6H')
int_loc = [df.index.get_indexer([i], method='nearest') for i in my_dt]
int_loc = np.array(int_loc).reshape(-1)
res = df.Radiation.iloc[int_loc]
res.tail(3)
```

之后，可以得到相应结果。